### PR TITLE
chore(lint): trim redundant migration comment from eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,6 @@
 /**
  * Flat ESLint config.
  *
- * ESLint v9 deprecated and v10 removed the legacy `.eslintrc.*` /
- * `.eslintignore` files, so this replaces the old config.
- *
  * Composition (in order):
  *   1. Ignores  — keep this first so subsequent blocks don't scan
  *      generated/vendored paths.


### PR DESCRIPTION
The ESLint-v9-deprecated preamble was useful in the migration commit but adds no value when reading the file as-is. The composition outline that follows is enough.